### PR TITLE
Fix websocket connection for production

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -21,7 +21,12 @@ module.exports = {
     port: 8080,
     assetsSubDirectory: 'static',
     assetsPublicPath: '/',
-    proxyTable: {},
+    proxyTable: {
+      '/socket.io': {
+         target: 'ws://localhost:3000',
+         ws: true
+      },
+    },
     // CSS Sourcemaps off by default because relative paths are "buggy"
     // with this option, according to the CSS-Loader README
     // (https://github.com/webpack/css-loader#sourcemaps)

--- a/src/main.js
+++ b/src/main.js
@@ -13,7 +13,7 @@ import ConversationsList from './components/ConversationsList';
 
 Vue.use(VueRouter)
 
-Vue.use(VueSocketio, '//:3000'); // Automatically socket connect from url string
+Vue.use(VueSocketio, '//'); // Automatically socket connect from url string
 
 const routes = [
   {


### PR DESCRIPTION
Proxy websockets through Webpack so it allows to connect directly to
current host. It means that we don't need to precise port number on
client-side so it's easier to set up on production.