### PR TITLE
Add information in case of connection loss

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,8 @@
 <template>
   <div id="app">
+    <div class="connection-info" v-show="disconnected">
+      Houston! We lost the connection!
+    </div>
     <router-view></router-view>
   </div>
 </template>
@@ -7,6 +10,11 @@
 <script>
 export default {
   name: 'app',
+  data() {
+    return {
+      disconnected: false
+    };
+  },
 	sockets: {
 		'err': function(err) {
 			console.log('An error occured: ', err);
@@ -14,6 +22,14 @@ export default {
     'auth failed': function(err) {
       console.log('redirecting to login');
       this.$router.push('/login');
+    },
+    'connect': function(err) {
+      console.log('Connected');
+      this.disconnected = false;
+    },
+    'disconnect': function(err) {
+      console.log('Got disconnected');
+      this.disconnected = true;
     }
 	}
 };
@@ -25,5 +41,16 @@ body { font: 13px 'WorkSans-Regular', Arial, sans-serif; }
 #app {
 	height: 100%;
 	overflow-x: hidden;
+}
+
+.connection-info {
+  position: fixed;
+  padding: 10px;
+  top: 50px;
+  width: 80%;
+  left: 10%;
+  background-color: #f0f0f0;
+  color: black;
+  z-index: 1;
 }
 </style>


### PR DESCRIPTION
Currently, if there is the websocket fails, the user has no feedback. This adds information in case of connection loss and in case of an update which requires the user to refresh the browser.